### PR TITLE
Support Java 8

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -14,9 +14,9 @@ jobs:
         name: Checkout project
     
       - uses: actions/setup-java@v2
-        name: Set up JDK 11
+        name: Set up JDK 8
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'temurin'
           cache: maven
         

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '8'
         distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # pstconv
 
 A java command line tool to convert proprietary Microsoft Outlook OST/PST files 
-to EML or MBOX format. OST/PST content is parsed and extracted with [java-libpst](https://github.com/rjohnsondev/java-libpst)
+to EML or MBOX format, even if the file is password protected. OST/PST content is 
+parsed and extracted with [java-libpst](https://github.com/rjohnsondev/java-libpst)
 library.
 
 # Requirements
 
-- Java Runtime Environment 11
+- Java Runtime Environment 8
 
 # Usage
 
@@ -28,7 +29,7 @@ usage: java -jar pstconv.jar [OPTIONS]
 
 To build this project you need:
 
-- Java Development Kit 11
+- Java Development Kit 8
 - Apache Maven 3.6.x
 
 Assuming all the tools can be found on the PATH, simply go to the project 

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     
     <scm>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.mnode.mstor</groupId>
             <artifactId>mstor</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>pt.cjmach</groupId>
     <artifactId>pstconv</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.5.0</version>
     <packaging>jar</packaging>
     <name>pstconv</name>
     <description>Command line tool to convert Outlook OST/PST files to EML/MBOX format</description>
@@ -16,7 +16,7 @@
     
     <scm>
         <developerConnection>scm:git:git@github.com:cjmach/pstconv.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>v0.5.0</tag>
   </scm>
     
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>pt.cjmach</groupId>
     <artifactId>pstconv</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>pstconv</name>
     <description>Command line tool to convert Outlook OST/PST files to EML/MBOX format</description>
@@ -16,7 +16,7 @@
     
     <scm>
         <developerConnection>scm:git:git@github.com:cjmach/pstconv.git</developerConnection>
-      <tag>v0.5.0</tag>
+      <tag>HEAD</tag>
   </scm>
     
     <distributionManagement>

--- a/src/main/java/pt/cjmach/pstconv/PstConverter.java
+++ b/src/main/java/pt/cjmach/pstconv/PstConverter.java
@@ -49,7 +49,7 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 import javax.mail.util.ByteArrayDataSource;
-import net.fortuna.mstor.model.MStorStore;
+import net.fortuna.mstor.MStorStore;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.mime.MimeTypes;


### PR DESCRIPTION
In order to provide integration with other tools, namely Autopsy, Java 8 is required to be supported. Major code change was the downgrade of mstor library to version 1.0.0.