### PR TITLE
Bug fixes

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout project
     
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         name: Set up JDK 8
         with:
           java-version: '8'

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -16,9 +16,9 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '8'
         distribution: 'temurin'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ library.
 ```console
 usage: java -jar pstconv.jar [OPTIONS]
  -e,--encoding <ENCODING>   Encoding to use for reading character data.
-                            Default is UTF-8.
+                            Default is ISO-8859-1.
  -f,--format <FORMAT>       Convert input file to one of the following
                             formats: mbox, eml. Default is eml.
  -h,--help                  Print help and exit.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>pt.cjmach</groupId>
     <artifactId>pstconv</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>pstconv</name>
     <description>Command line tool to convert Outlook OST/PST files to EML/MBOX format</description>
@@ -16,7 +16,7 @@
     
     <scm>
         <developerConnection>scm:git:git@github.com:cjmach/pstconv.git</developerConnection>
-        <tag>v0.9.1</tag>
+        <tag>HEAD</tag>
     </scm>
     
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>pt.cjmach</groupId>
     <artifactId>pstconv</artifactId>
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.9.1</version>
     <packaging>jar</packaging>
     <name>pstconv</name>
     <description>Command line tool to convert Outlook OST/PST files to EML/MBOX format</description>
@@ -16,7 +16,7 @@
     
     <scm>
         <developerConnection>scm:git:git@github.com:cjmach/pstconv.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v0.9.1</tag>
     </scm>
     
     <distributionManagement>

--- a/src/main/java/pt/cjmach/pstconv/Launcher.java
+++ b/src/main/java/pt/cjmach/pstconv/Launcher.java
@@ -43,25 +43,25 @@ public class Launcher implements Callable<Integer> {
     /**
      * 
      */
-    @Option(names = {"-i", "--input"}, paramLabel = "FILE", required = true,
+    @Option(names = {"-i", "--input"}, paramLabel = "FILE", required = true, // NOI18N
             description = "Path to OST/PST input file. Required option.")
     private File inputFile;
     /**
      * 
      */
-    @Option(names = {"-o", "--output"}, paramLabel = "DIRECTORY", required = true,
+    @Option(names = {"-o", "--output"}, paramLabel = "DIRECTORY", required = true, // NOI18N
             description = "Path to Mbox/EML output directory. If it doesn't exist, the application will attempt to create it. Required option.")
     private File outputDirectory;
     /**
      * 
      */
-    @Option(names = {"-f", "--format"}, paramLabel = "FORMAT", defaultValue = "EML",
+    @Option(names = {"-f", "--format"}, paramLabel = "FORMAT", defaultValue = "EML", // NOI18N
             description = "Convert input file to one of the following formats: ${COMPLETION-CANDIDATES}. Default is ${DEFAULT-VALUE}.")
     private MailMessageFormat outputFormat;
     /**
      * 
      */
-    @Option(names = {"-e", "--encoding"}, paramLabel = "ENCODING", defaultValue = "ISO-8859-1",
+    @Option(names = {"-e", "--encoding"}, paramLabel = "ENCODING", defaultValue = "ISO-8859-1", // NOI18N
             description = "Encoding to use for reading character data. Default is ${DEFAULT-VALUE}.")
     private String encoding;
     /**
@@ -104,7 +104,7 @@ public class Launcher implements Callable<Integer> {
         int exitCode = cmdLine.execute(args);
         if (cmdLine.isVersionHelpRequested()) {
             String version = getVersion();
-            System.out.println("pstconv " + version);
+            System.out.println("pstconv " + version); // NOI18N
         }
         // The application is not finished if the mstor storage provider is used. It 
         // creates a few threads that remain running after processing the PST file.
@@ -118,9 +118,9 @@ public class Launcher implements Callable<Integer> {
      */
     private static String getVersion() {
         try {
-            Manifest manifest = new Manifest(Launcher.class.getResourceAsStream("/META-INF/MANIFEST.MF"));
+            Manifest manifest = new Manifest(Launcher.class.getResourceAsStream("/META-INF/MANIFEST.MF")); // NOI18N
             Attributes attributes = manifest.getMainAttributes();
-            String version = attributes.getValue("Implementation-Version");
+            String version = attributes.getValue("Implementation-Version"); // NOI18N
             return version;
         } catch (IOException ex) {
             logger.error("Could not read MANIFEST.MF file", ex);

--- a/src/main/java/pt/cjmach/pstconv/Launcher.java
+++ b/src/main/java/pt/cjmach/pstconv/Launcher.java
@@ -61,7 +61,7 @@ public class Launcher implements Callable<Integer> {
     /**
      * 
      */
-    @Option(names = {"-e", "--encoding"}, paramLabel = "ENCODING", defaultValue = "UTF-8",
+    @Option(names = {"-e", "--encoding"}, paramLabel = "ENCODING", defaultValue = "ISO-8859-1",
             description = "Encoding to use for reading character data. Default is ${DEFAULT-VALUE}.")
     private String encoding;
     /**

--- a/src/main/java/pt/cjmach/pstconv/MailMessageFormat.java
+++ b/src/main/java/pt/cjmach/pstconv/MailMessageFormat.java
@@ -20,8 +20,8 @@ package pt.cjmach.pstconv;
  * @author cmachado
  */
 public enum MailMessageFormat {
-    MBOX("mbox"),
-    EML("eml");
+    MBOX("mbox"), // NOI18N
+    EML("eml"); // NOI18N
 
     public final String format;
 

--- a/src/main/java/pt/cjmach/pstconv/PstConverter.java
+++ b/src/main/java/pt/cjmach/pstconv/PstConverter.java
@@ -416,7 +416,8 @@ public class PstConverter {
 
                 attachmentBodyPart.setContentID(attachment.getContentId());
 
-                String fileName = coalesce("", attachment.getLongFilename(), attachment.getDisplayName(), attachment.getFilename());
+                String fileName = coalesce("fileId-" + attachment.getDescriptorNodeId(), 
+                        attachment.getLongFilename(), attachment.getDisplayName(), attachment.getFilename());
                 attachmentBodyPart.setFileName(fileName);
 
                 rootMultipart.addBodyPart(attachmentBodyPart);
@@ -477,7 +478,7 @@ public class PstConverter {
 
     static String coalesce(String defaultValue, String... args) {
         for (String arg : args) {
-            if (arg != null) {
+            if (arg != null && !arg.isEmpty()) {
                 return arg;
             }
         }

--- a/src/main/java/pt/cjmach/pstconv/PstConverter.java
+++ b/src/main/java/pt/cjmach/pstconv/PstConverter.java
@@ -70,7 +70,7 @@ public class PstConverter {
      * Name of the custom header added to each converted message to allow to
      * easily trace back the original message from OST/PST file.
      */
-    public static final String DESCRIPTOR_ID_HEADER = "X-Outlook-Descriptor-Id";
+    public static final String DESCRIPTOR_ID_HEADER = "X-Outlook-Descriptor-Id"; // NOI18N
 
     /**
      * Default constructor.
@@ -88,14 +88,14 @@ public class PstConverter {
 
             case MBOX: {
                 // see: https://github.com/micronode/mstor#system-properties
-                System.setProperty("mstor.mbox.metadataStrategy", "none");
-                System.setProperty("mstor.mbox.encoding", encoding);
-                System.setProperty("mstor.mbox.bufferStrategy", "default");
-                System.setProperty("mstor.cache.disabled", "true");
+                System.setProperty("mstor.mbox.metadataStrategy", "none"); // NOI18N
+                System.setProperty("mstor.mbox.encoding", encoding); // NOI18N
+                System.setProperty("mstor.mbox.bufferStrategy", "default"); // NOI18N
+                System.setProperty("mstor.cache.disabled", "true"); // NOI18N
                 
                 Properties sessionProps = new Properties(System.getProperties());
                 Session session = Session.getDefaultInstance(sessionProps);
-                return new MStorStore(session, new URLName("mstor:" + directory));
+                return new MStorStore(session, new URLName("mstor:" + directory)); // NOI18N
             }
             default:
                 throw new IllegalArgumentException("Unsupported mail format: " + format);
@@ -124,7 +124,7 @@ public class PstConverter {
         Charset.forName(encoding); // throws UnsupportedCharsetException if encoding is invalid
 
         // see: https://docs.oracle.com/javaee/6/api/javax/mail/internet/package-summary.html#package_description
-        System.setProperty("mail.mime.address.strict", "false");
+        System.setProperty("mail.mime.address.strict", "false"); // NOI18N
         Set<Long> result = new TreeSet<>();
         Store store = createStore(directory, format, encoding);
         try {
@@ -213,7 +213,7 @@ public class PstConverter {
         Charset charset = Charset.forName(encoding); // throws UnsupportedCharsetException if encoding is invalid
 
         // see: https://docs.oracle.com/javaee/6/api/javax/mail/internet/package-summary.html#package_description
-        System.setProperty("mail.mime.address.strict", "false");
+        System.setProperty("mail.mime.address.strict", "false"); // NOI18N
         long messageCount = 0;
 
         if (!outputDirectory.exists() && !outputDirectory.mkdirs()) {
@@ -322,7 +322,7 @@ public class PstConverter {
         if (messageHeaders != null && !messageHeaders.isEmpty()) {
             try (InputStream headersStream = new ByteArrayInputStream(messageHeaders.getBytes(charset))) {
                 InternetHeaders headers = new InternetHeaders(headersStream);
-                headers.removeHeader("Content-Type");
+                headers.removeHeader("Content-Type"); // NOI18N
 
                 Enumeration<Header> allHeaders = headers.getAllHeaders();
 
@@ -330,16 +330,16 @@ public class PstConverter {
                     Header header = allHeaders.nextElement();
                     mimeMessage.addHeader(header.getName(), header.getValue());
                 }
-                String dateHeader = mimeMessage.getHeader("Date", null);
+                String dateHeader = mimeMessage.getHeader("Date", null); // NOI18N
                 if (dateHeader == null || dateHeader.isEmpty()) {
-                    mimeMessage.addHeader("Date", RFC822_DATE_FORMAT.format(message.getMessageDeliveryTime()));
+                    mimeMessage.addHeader("Date", RFC822_DATE_FORMAT.format(message.getMessageDeliveryTime())); // NOI18N
                 }
             }
         } else {
             mimeMessage.setSubject(message.getSubject());
             Date sentDate = message.getClientSubmitTime();
             if (sentDate == null) {
-                mimeMessage.addHeader("Date", "");
+                mimeMessage.addHeader("Date", ""); // NOI18N
             } else {
                 mimeMessage.setSentDate(sentDate);
             }
@@ -384,7 +384,7 @@ public class PstConverter {
 
         if (messageBodyHTML != null && !messageBodyHTML.isEmpty()) {
             MimeBodyPart htmlBodyPart = new MimeBodyPart();
-            htmlBodyPart.setDataHandler(new DataHandler(new ByteArrayDataSource(messageBodyHTML, "text/html")));
+            htmlBodyPart.setDataHandler(new DataHandler(new ByteArrayDataSource(messageBodyHTML, "text/html"))); // NOI18N
             contentMultipart.addBodyPart(htmlBodyPart);
         } else if (messageBody != null && !messageBody.isEmpty()) {
             MimeBodyPart textBodyPart = new MimeBodyPart();
@@ -393,8 +393,8 @@ public class PstConverter {
         } else {
             MimeBodyPart textBodyPart = new MimeBodyPart();
             textBodyPart.setText("");
-            textBodyPart.addHeaderLine("Content-Type: text/plain; charset=\"utf-8\"");
-            textBodyPart.addHeaderLine("Content-Transfer-Encoding: quoted-printable");
+            textBodyPart.addHeaderLine("Content-Type: text/plain; charset=\"utf-8\""); // NOI18N
+            textBodyPart.addHeaderLine("Content-Transfer-Encoding: quoted-printable"); // NOI18N
             contentMultipart.addBodyPart(textBodyPart);
         }
         MimeBodyPart contentBodyPart = new MimeBodyPart();
@@ -416,7 +416,7 @@ public class PstConverter {
 
                 attachmentBodyPart.setContentID(attachment.getContentId());
 
-                String fileName = coalesce("fileId-" + attachment.getDescriptorNodeId(), 
+                String fileName = coalesce("attachment-" + attachment.getDescriptorNodeId(),   // NOI18N
                         attachment.getLongFilename(), attachment.getDisplayName(), attachment.getFilename());
                 attachmentBodyPart.setFileName(fileName);
 


### PR DESCRIPTION
- Ensure an attachment always has a filename.
- Set default encoding to ISO-8859-1 as this is the one used by JavaMail and MStor libraries.
- Improve error message to clearly identify when the encoding in use is invalid.